### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ master | dev
 # install dependencies
 npm install
 # run local server on :4000 using the offical Graphcool API
-BACKEND_ADDR="https://api.graph.cool" npm start
+env BACKEND_ADDR="https://api.graph.cool" npm start
 ```
 ### IDE Setup (Webstorm)
 


### PR DESCRIPTION
Error triggered when typing  `BACKEND_ADDR=https://api.graph.cool npm start` in Terminal :

*Unsupported use of '='. To run 'npm' with a modified environment, please use 'env BACKEND_ADDR=https://api.graph.cool npm start'*